### PR TITLE
Mailchimp Dropdown Field Support

### DIFF
--- a/admin/admin-menu-and-tabs.php
+++ b/admin/admin-menu-and-tabs.php
@@ -260,7 +260,7 @@ class Disciple_Tools_Mailchimp_Tab_General {
         return ! empty( $supported_lists ) ? $supported_lists : '{}';
     }
 
-    private function fetch_dt_assigned_user_id(): int {
+    private function fetch_dt_assigned_user_id() {
         return get_option( 'dt_mailchimp_dt_new_record_assign_user_id' );
     }
 
@@ -418,7 +418,7 @@ class Disciple_Tools_Mailchimp_Tab_General {
                             if ( ! empty( $users ) && ! is_wp_error( $users ) ) {
                                 $assigned_user = $this->fetch_dt_assigned_user_id();
                                 foreach ( $users as $user ) {
-                                    $selected = ( intval( $user['ID'] ) === intval( $assigned_user ) ) ? 'selected' : '';
+                                    $selected = ( is_int( $assigned_user ) && intval( $user['ID'] ) === intval( $assigned_user ) ) ? 'selected' : '';
                                     echo '<option ' . esc_attr( $selected ) . ' value="' . esc_attr( $user['ID'] ) . '">' . esc_attr( $user['name'] ) . '</option>';
                                 }
                             }
@@ -992,6 +992,14 @@ class Disciple_Tools_Mailchimp_Tab_Mappings {
 
         Ensure Mailchimp interest category group fields are only mapped with DT multi_select types. No other type pairings will be sync'd at this time.
         <br><br>
+        In addition to interest category groups, the following Mailchimp field types are also supported:
+        <br>
+        <ul>
+            <li>- Text</li>
+            <li>- Phone</li>
+            <li>- Dropdowns</li>
+        </ul>
+        <hr>
 
         <span style="float:right;">
             <a id="mc_mappings_main_col_selected_mc_list_add_mapping_but"

--- a/disciple-tools-mailchimp.php
+++ b/disciple-tools-mailchimp.php
@@ -5,7 +5,7 @@
  * Description: Disciple.Tools - Mailchimp plugin is intended to integrate Mailchimp with the Disciple.Tools system.
  * Text Domain: disciple-tools-mailchimp
  * Domain Path: /languages
- * Version:  1.2
+ * Version:  1.3
  * Author URI: https://github.com/DiscipleTools
  * GitHub Plugin URI: https://github.com/DiscipleTools/disciple-tools-mailchimp
  * Requires at least: 4.7.0

--- a/mailchimp-api/mailchimp-api.php
+++ b/mailchimp-api/mailchimp-api.php
@@ -70,7 +70,8 @@ class Disciple_Tools_Mailchimp_API {
                 array_unshift( $response->merge_fields, (object) [
                     "merge_id" => "0",
                     "tag"      => "EMAIL",
-                    "name"     => "Email"
+                    "name"     => "Email",
+                    "type"     => "email"
                 ] );
             }
 
@@ -84,14 +85,29 @@ class Disciple_Tools_Mailchimp_API {
                     }
                 }
 
-                return $filtered_fields;
+                return self::remove_unsupported_list_field_types( $filtered_fields );
 
             } else {
-                return $response->merge_fields;
+                return self::remove_unsupported_list_field_types( $response->merge_fields );
             }
         } else {
             return [];
         }
+    }
+
+    private static function remove_unsupported_list_field_types( $fields ): array {
+
+        // Currently, supported field types
+        $supported_field_types = [ 'email', 'text', 'phone', 'dropdown' ];
+
+        $valid_fields = [];
+        foreach ( $fields as $field ) {
+            if ( in_array( trim( strtolower( $field->type ) ), $supported_field_types ) ) {
+                $valid_fields[] = $field;
+            }
+        }
+
+        return $valid_fields;
     }
 
     public static function get_list_interest_categories( $list_id, $load_interests = false ): array {

--- a/version-control.json
+++ b/version-control.json
@@ -1,8 +1,8 @@
 {
 
   "name": "Disciple.Tools - Mailchimp Integration",
-  "version": "1.2",
-  "last_updated": "2021-07",
+  "version": "1.3",
+  "last_updated": "2021-10",
   "author": "Disciple.Tools",
   "author_homepage": "https://disciple.tools",
   "git_owner": "DiscipleTools",


### PR DESCRIPTION
- Plugin now supports mapping with Mailchimp dropdown field types.
- Plugin now enforces mapping between Mailchimp field types which are only supported.